### PR TITLE
Implement RNN decoding; feed output t-1 as input t

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2256,7 +2256,7 @@ def rnn(step_function, inputs, initial_states,
                 successive_states.append(states)
 
         for _ in range(decode):
-            output, states = step_function(successive_outputs[-1], successive_states[-1] + constants)
+            output, states = step_function(successive_outputs[-1], successive_states[-1] + constants, True)
             successive_outputs.append(output)
             successive_states.append(states)
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2153,8 +2153,8 @@ def rnn(step_function, inputs, initial_states,
         input_length: not relevant in the TensorFlow implementation.
             Must be specified if using unrolling with Theano.
         output_length: length of output sequences.
-            If greater than input length, the RNN output will be used as input.
-            `unroll` must be true for this to have effect.
+            When greater than input length, the RNN output will be used as input.
+            `unroll` must be true.
 
     # Returns
         A tuple, `(last_output, outputs, new_states)`.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2122,7 +2122,7 @@ def stop_gradient(variables):
 
 def rnn(step_function, inputs, initial_states,
         go_backwards=False, mask=None, constants=None,
-        unroll=False, input_length=None):
+        unroll=False, input_length=None, output_length=None):
     """Iterates over the time dimension of a tensor.
 
     # Arguments
@@ -2152,6 +2152,9 @@ def rnn(step_function, inputs, initial_states,
         unroll: whether to unroll the RNN or to use a symbolic loop (`while_loop` or `scan` depending on backend).
         input_length: not relevant in the TensorFlow implementation.
             Must be specified if using unrolling with Theano.
+        output_length: length of output sequences.
+            If greater than input length, the RNN output will be used as input.
+            `unroll` must be true for this to have effect.
 
     # Returns
         A tuple, `(last_output, outputs, new_states)`.
@@ -2168,6 +2171,8 @@ def rnn(step_function, inputs, initial_states,
         ValueError: if `unroll` is `True` but input timestep is not a fixed number.
         ValueError: if `mask` is provided (not `None`) but states is not provided
             (`len(states)` == 0).
+        ValueError: if input length (timesteps) is greater than `output_length`.
+        ValueError: if `output_length` is set and `unroll` is False.
     """
     ndim = len(inputs.get_shape())
     if ndim < 3:
@@ -2189,6 +2194,7 @@ def rnn(step_function, inputs, initial_states,
         if not inputs.get_shape()[0]:
             raise ValueError('Unrolling requires a '
                              'fixed number of timesteps.')
+
         states = initial_states
         successive_states = []
         successive_outputs = []
@@ -2196,6 +2202,13 @@ def rnn(step_function, inputs, initial_states,
         input_list = tf.unstack(inputs)
         if go_backwards:
             input_list.reverse()
+
+        if output_length is None:
+            output_length = len(input_list)
+        decode = output_length - len(input_list)
+        if decode < 0:
+            raise ValueError('Output length has to be greater '
+                             'or equal to input length (timesteps).')
 
         if mask is not None:
             mask_list = tf.unstack(mask)
@@ -2236,19 +2249,24 @@ def rnn(step_function, inputs, initial_states,
                 states = return_states
                 successive_outputs.append(output)
                 successive_states.append(states)
-                last_output = successive_outputs[-1]
-                new_states = successive_states[-1]
-                outputs = tf.stack(successive_outputs)
         else:
             for inp in input_list:
                 output, states = step_function(inp, states + constants)
                 successive_outputs.append(output)
                 successive_states.append(states)
-            last_output = successive_outputs[-1]
-            new_states = successive_states[-1]
-            outputs = tf.stack(successive_outputs)
 
+        for _ in range(decode):
+            output, states = step_function(successive_outputs[-1], successive_states[-1] + constants)
+            successive_outputs.append(output)
+            successive_states.append(states)
+
+        last_output = successive_outputs[-1]
+        new_states = successive_states[-1]
+        outputs = tf.stack(successive_outputs)
     else:
+        if output_length:
+            raise ValueError('`output_length` requires `unroll` to be True.')
+
         if go_backwards:
             inputs = reverse(inputs, 0)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1145,7 +1145,7 @@ def rnn(step_function, inputs, initial_states,
         decode = output_length - input_length
         if decode < 0:
             raise ValueError('Output length has to be greater '
-                                'or equal to input length (timesteps).')
+                             'or equal to input length (timesteps).')
     elif output_length:
         raise ValueError('`output_length` requires `unroll` to be True.')
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1120,8 +1120,8 @@ def rnn(step_function, inputs, initial_states,
         unroll: whether to unroll the RNN or to use a symbolic loop (`while_loop` or `scan` depending on backend).
         input_length: must be specified if using `unroll`.
         output_length: length of output sequences.
-            If greater than input length, the RNN output will be used as input.
-            `unroll` must be true for this to have effect.
+            When greater than input length, the RNN output will be used as input.
+            `unroll` must be true.
 
     # Returns
         A tuple (last_output, outputs, new_states).

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1093,7 +1093,7 @@ def stop_gradient(variables):
 
 def rnn(step_function, inputs, initial_states,
         go_backwards=False, mask=None, constants=None,
-        unroll=False, input_length=None):
+        unroll=False, input_length=None, output_length=None):
     """Iterates over the time dimension of a tensor.
 
     # Arguments
@@ -1119,6 +1119,9 @@ def rnn(step_function, inputs, initial_states,
         constants: a list of constant values passed at each step.
         unroll: whether to unroll the RNN or to use a symbolic loop (`while_loop` or `scan` depending on backend).
         input_length: must be specified if using `unroll`.
+        output_length: length of output sequences.
+            If greater than input length, the RNN output will be used as input.
+            `unroll` must be true for this to have effect.
 
     # Returns
         A tuple (last_output, outputs, new_states).
@@ -1131,6 +1134,15 @@ def rnn(step_function, inputs, initial_states,
     """
     ndim = inputs.ndim
     assert ndim >= 3, 'Input should be at least 3D.'
+
+    if output_length is None:
+        output_length = input_length
+    elif not unroll:
+        raise ValueError('`output_length` requires `unroll` to be True.')
+    decode = output_length - input_length
+    if decode < 0:
+        raise ValueError('Output length has to be greater '
+                         'or equal to input length (timesteps).')
 
     if unroll:
         if input_length is None:
@@ -1172,6 +1184,11 @@ def rnn(step_function, inputs, initial_states,
                     kept_states.append(T.switch(mask[i], new_state, state))
                 states = kept_states
 
+                successive_outputs.append(output)
+                successive_states.append(states)
+
+            for _ in range(decode):
+                output, states = step_function(successive_outputs[-1], successive_states[-1] + constants)
                 successive_outputs.append(output)
                 successive_states.append(states)
 
@@ -1223,6 +1240,12 @@ def rnn(step_function, inputs, initial_states,
                 output, states = step_function(inputs[i], states + constants)
                 successive_outputs.append(output)
                 successive_states.append(states)
+
+            for _ in range(decode):
+                output, states = step_function(successive_outputs[-1], successive_states[-1] + constants)
+                successive_outputs.append(output)
+                successive_states.append(states)
+
             outputs = T.stack(*successive_outputs)
             states = []
             for i in range(len(successive_states[-1])):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1135,20 +1135,19 @@ def rnn(step_function, inputs, initial_states,
     ndim = inputs.ndim
     assert ndim >= 3, 'Input should be at least 3D.'
 
-    if output_length is None:
-        output_length = input_length
-    elif not unroll:
-        raise ValueError('`output_length` requires `unroll` to be True.')
-    decode = output_length - input_length
-    if decode < 0:
-        raise ValueError('Output length has to be greater '
-                         'or equal to input length (timesteps).')
-
     if unroll:
         if input_length is None:
             raise ValueError('When specifying `unroll=True`, '
                              'an `input_length` '
                              'must be provided to `rnn`.')
+        if output_length is None:
+            output_length = input_length
+        decode = output_length - input_length
+        if decode < 0:
+            raise ValueError('Output length has to be greater '
+                                'or equal to input length (timesteps).')
+    elif output_length:
+        raise ValueError('`output_length` requires `unroll` to be True.')
 
     axes = [1, 0] + list(range(2, ndim))
     inputs = inputs.dimshuffle(axes)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1187,7 +1187,7 @@ def rnn(step_function, inputs, initial_states,
                 successive_states.append(states)
 
             for _ in range(decode):
-                output, states = step_function(successive_outputs[-1], successive_states[-1] + constants)
+                output, states = step_function(successive_outputs[-1], successive_states[-1] + constants, True)
                 successive_outputs.append(output)
                 successive_states.append(states)
 
@@ -1241,7 +1241,7 @@ def rnn(step_function, inputs, initial_states,
                 successive_states.append(states)
 
             for _ in range(decode):
-                output, states = step_function(successive_outputs[-1], successive_states[-1] + constants)
+                output, states = step_function(successive_outputs[-1], successive_states[-1] + constants, True)
                 successive_outputs.append(output)
                 successive_states.append(states)
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -129,7 +129,8 @@ class Recurrent(Layer):
             at the level of the first layer
             (e.g. via the `input_shape` argument)
         output_length: Length of output sequences.
-            If greater than input length, the RNN output will be used as input.
+            When greater than input length, the RNN output will be used as input.
+            `unroll` must be true.
 
     # Input shapes
         3D tensor with shape `(batch_size, timesteps, input_dim)`,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -370,7 +370,8 @@ class Recurrent(Layer):
                   'go_backwards': self.go_backwards,
                   'stateful': self.stateful,
                   'unroll': self.unroll,
-                  'implementation': self.implementation}
+                  'implementation': self.implementation,
+                  'output_length': self.output_length}
         base_config = super(Recurrent, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -212,7 +212,7 @@ class Recurrent(Layer):
         else:
             return None
 
-    def step(self, inputs, states):
+    def step(self, inputs, states, is_output=False):
         raise NotImplementedError
 
     def get_constants(self, inputs, training=None):
@@ -513,7 +513,7 @@ class SimpleRNN(Recurrent):
                                            timesteps,
                                            training=training)
 
-    def step(self, inputs, states):
+    def step(self, inputs, states, is_output=False):
         if self.implementation == 0:
             h = inputs
         else:
@@ -786,12 +786,12 @@ class GRU(Recurrent):
             constants.append([K.cast_to_floatx(1.) for _ in range(3)])
         return constants
 
-    def step(self, inputs, states):
+    def step(self, inputs, states, is_output=False):
         h_tm1 = states[0]  # previous memory
         dp_mask = states[1]  # dropout matrices for recurrent units
         rec_dp_mask = states[2]
 
-        if self.implementation == 2:
+        if self.implementation == 2 or is_output:
             matrix_x = K.dot(inputs * dp_mask[0], self.kernel)
             if self.use_bias:
                 matrix_x = K.bias_add(matrix_x, self.bias)
@@ -1076,13 +1076,13 @@ class LSTM(Recurrent):
             constants.append([K.cast_to_floatx(1.) for _ in range(4)])
         return constants
 
-    def step(self, inputs, states):
+    def step(self, inputs, states, is_output=False):
         h_tm1 = states[0]
         c_tm1 = states[1]
         dp_mask = states[2]
         rec_dp_mask = states[3]
 
-        if self.implementation == 2:
+        if self.implementation == 2 or is_output:
             z = K.dot(inputs * dp_mask[0], self.kernel)
             z += K.dot(h_tm1 * rec_dp_mask[0], self.recurrent_kernel)
             if self.use_bias:

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -218,6 +218,7 @@ def test_reset_states_with_values(layer_class):
                                np.ones(K.int_shape(layer.states[0])),
                                atol=1e-4)
 
+
 @rnn_test
 def test_output_length(layer_class):
     output_length = 10

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -218,5 +218,26 @@ def test_reset_states_with_values(layer_class):
                                np.ones(K.int_shape(layer.states[0])),
                                atol=1e-4)
 
+@rnn_test
+def test_output_length(layer_class):
+    output_length = 10
+    input_length = 2
+    input_seq = Input((input_length, units))
+
+    models = []
+    for i in range(3):
+        layer = layer_class(units, return_sequences=True,
+                            implementation=i,
+                            unroll=True,
+                            output_length=output_length)(input_seq)
+        models.append(Model(input_seq, layer))
+        models[-1].compile(loss='mse', optimizer='adam')
+
+    inputs = np.random.random((num_samples, input_length, units))
+    targets = np.random.random((num_samples, output_length, units))
+
+    for model in models:
+        model.fit(inputs, targets)
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Adds an optional argument `output_length` to the `Recurrent` layer, if `output_length` is greater than the input sequence, then after processing the input, the output of the RNN from timestep `t-1` will be used as input at timestep `t` to generate the remaining output sequence.

```
input_seq = Input((16, 32))

# Output: `(batch, 32)`
encoder = GRU(32)(input_seq)

# Output: `(batch, 1, 32)`
# Can repeat more than once.
input_decoder = RepeatVector(1)(encoder)

# Output: `(batch, 16, 32)`
# Use the encoder's output as the initial input for the decoder.
# Then the decoder feeds its output from timestep `t-1` as input at timestep `t` to generate the rest of the output sequence.
decoder = GRU(32, unroll=True, output_length=16)(input_decoder)
```

This feature is necessary for a Seq2Seq model, especially if we want to have a seq2seq example script in the `examples/` folder as @fchollet mentioned here - #5559 (I'm on it).

I tested it on latest TF and theano and it works as expected.